### PR TITLE
8th Legion Starting Stuff

### DIFF
--- a/common/countries/8thLegion.txt
+++ b/common/countries/8thLegion.txt
@@ -1,0 +1,4 @@
+﻿graphical_culture = commonwealth_gfx
+graphical_culture_2d = commonwealth_2d
+
+color = { 203 23 23 }

--- a/common/country_tags/00_countries.txt
+++ b/common/country_tags/00_countries.txt
@@ -70,3 +70,4 @@ NEN = "countries/north_army.txt"
 #Red Eye Puppet States
 RSH = "countries/RedEyeShatteredHoof.txt"
 MAS = "countries/MAS.txt"
+LEG = "countries/8thLegion.txt

--- a/events/8th_legion_events.txt
+++ b/events/8th_legion_events.txt
@@ -1,0 +1,38 @@
+add_namespace = legion8
+
+country_event = {
+    id = legion8.1
+    title = legion8.1.t
+    desc = legion8.1.d
+
+    fire_only_once = yes
+    mean_time_to_happen = {
+        days = 1
+    }
+
+    trigger = {
+        tag = EMP
+        NOT = {
+            is_ai = yes
+        }
+    }
+
+    option = {
+        name = legion8.1.a
+        LEG = {
+           transfer_state = 44
+           transfer_state = 436
+           transfer_state = 66
+           transfer_state = 51
+        }
+        LEG = { change_tag_from = EMP }
+        LEG = {
+            annex_country = {
+                target = EMP
+                transfer_troops = no
+            }
+        }
+        
+        
+    }
+}

--- a/history/countries/LEG - 8thLegion.txt
+++ b/history/countries/LEG - 8thLegion.txt
@@ -1,0 +1,22 @@
+﻿capital = 51
+
+set_research_slot = 3
+
+set_technology = {
+	pony_race = 1
+	tribal_civilization = 1
+	settled_civilization = 1
+	standard_weaponry_tech = 1
+	ballistic_weaponry_tech_1 = 1
+	melee_weaponry_tech_1 = 1
+	support_weaponry = 1
+}
+
+set_stability = 0.7
+
+set_popularities = {
+    suvivalism = 10
+    continutation = 10
+    visionary = 40
+    destruction = 40
+}

--- a/localisation/countries_l_english.yml
+++ b/localisation/countries_l_english.yml
@@ -844,3 +844,8 @@ FET_survivalism_ADJ:0 "Manehattanite"
 FET_continuation_ADJ:0 "Manehattanite"
 FET_visionary_ADJ:0 "Manehattanite"
 
+LEG_continutation:0 "8th Legion"
+LEG_destruction:0 "8th Legion"
+LEG_visionary:0 "8th Legion"
+LEG_survivalism:0 "8th Legion"
+

--- a/localisation/country_LEG_l_english.yml
+++ b/localisation/country_LEG_l_english.yml
@@ -1,0 +1,10 @@
+﻿ l_english:
+
+##############################
+## Focus to Load 8th Legion ##
+##############################
+
+legion8.1.t:0 "Just a train station?"
+legion8.1.d:0 "For years the north of the equestrian wasteland has been a relatively quiet place, too far away from the busy trade routes that supply Manehattan to the south and too desolate for factions like the Steelrangers to bother exploring. On the surface, this area of the Equestrian wasteland is an expanse of nothing dotted with small villages. Inhabited by raiders, farmers, and wanderers all trying to survive.\n\nHowever, amid this seemingly normal piece of wasteland a lone train station lays. The fading black paint, smeared by wind and sand reads Four Stars Transportation Hub North. To any casual passerby this old train station with blasted windows and entrances hidden by rubble is just another casualty of the great war. But this train station is not what it seems. Much like its builder Four Stars, its history and true purpose is much darker than simply fulfilling the transportation needs of the old world ponies.\n\nTo a more experienced observer, the station is oddly placed. There are no destroyed suburbs or office buildings. No noticeable landmarks. No infrastructure one would expect to see near what appears to be a massive transportation hub. Only rusted construction equipment and spare pieces sitting out front. Which is odd, because the old equipment and material outside seems suitable to build a second station, and FS North while worn by time seems to have been ready to open any minute before the bombs fell. And yet, the equipment outfront makes it looks as if construction just started on that fateful day.\n\nIf somepony looks closely, it becomes clear this station is not a simple relic of the old world. Its purpose is unknown, and its location makes no sense when examining the surrounding wasteland. One has to wonder what secrets lie buried under this mysterious station’s exterior?"
+legion8.1.a:0 "Who puts a train station in the middle of nowhere?"
+


### PR DESCRIPTION
Opening event for empire that changes to the 8th legion. Helps keeps Empire as a historical generic when played by AI. All files set up for 8th legion.